### PR TITLE
Fix cross-platform compilation for darwin and windows

### DIFF
--- a/idspoof/internal/platform/platform_other.go
+++ b/idspoof/internal/platform/platform_other.go
@@ -1,0 +1,17 @@
+//go:build !linux
+
+package platform
+
+import "fmt"
+
+func newLinuxPlatform() Platform {
+	panic("newLinuxPlatform called on non-Linux platform")
+}
+
+func newDarwinPlatform() (Platform, error) {
+	return nil, fmt.Errorf("macOS platform not yet implemented")
+}
+
+func newWindowsPlatform() (Platform, error) {
+	return nil, fmt.Errorf("Windows platform not yet implemented")
+}

--- a/idspoof/internal/ui/color.go
+++ b/idspoof/internal/ui/color.go
@@ -1,21 +1,6 @@
 package ui
 
-import (
-	"os"
-
-	"golang.org/x/sys/unix"
-)
-
 var colorsEnabled bool
-
-func init() {
-	colorsEnabled = isTerminal(os.Stdout.Fd())
-}
-
-func isTerminal(fd uintptr) bool {
-	_, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
-	return err == nil
-}
 
 // ANSI escape codes.
 const (

--- a/idspoof/internal/ui/color_linux.go
+++ b/idspoof/internal/ui/color_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+
+package ui
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	colorsEnabled = isTerminal(os.Stdout.Fd())
+}
+
+func isTerminal(fd uintptr) bool {
+	_, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
+	return err == nil
+}

--- a/idspoof/internal/ui/color_other.go
+++ b/idspoof/internal/ui/color_other.go
@@ -1,0 +1,19 @@
+//go:build !linux
+
+package ui
+
+import "os"
+
+func init() {
+	colorsEnabled = isTerminal(os.Stdout.Fd())
+}
+
+func isTerminal(fd uintptr) bool {
+	// Best-effort: check if stdout is not being redirected.
+	// Works on macOS/Windows without unix package.
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}


### PR DESCRIPTION
Split unix.TCGETS terminal detection into color_linux.go/color_other.go so darwin/windows builds don't pull in the linux-only unix package. Add platform_other.go stub so newLinuxPlatform symbol resolves on all targets.